### PR TITLE
Fix error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Shows a spinner
 // start the spinner
 cli.action.start('starting a process')
 // show on stdout instead of stderr
-cli.action.start('starting a process', {stdout: true})
+cli.action.start('starting a process', null, {stdout: true})
 
 // stop the spinner
 cli.action.stop() // shows 'starting a process... done'


### PR DESCRIPTION
The method for directing the spinner to STDERR is not correct. The options arg is the 3rd argument to ```start()```.